### PR TITLE
hotfix/22 Проверка была ли авторизация через выбранную соц.сеть у другого пользователя

### DIFF
--- a/src/Security/Authenticator/Front/GithubRusAuthenticator.php
+++ b/src/Security/Authenticator/Front/GithubRusAuthenticator.php
@@ -6,6 +6,7 @@ namespace App\Security\Authenticator\Front;
 
 use App\Entity\User;
 use App\Event\UserLoggedInViaSocialNetworkEvent;
+use App\Utils\Authenticator\CheckingUserSocialNetworkBeforeAuthorization;
 use App\Utils\Factory\UserFactory;
 use App\Utils\Generator\PasswordGenerator;
 use App\Utils\Manager\UserManager;
@@ -27,34 +28,24 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
 class GithubRusAuthenticator extends OAuth2Authenticator
 {
-    /**
-     * @var ClientRegistry
-     */
+    use CheckingUserSocialNetworkBeforeAuthorization;
+
+    /** @var ClientRegistry */
     private $clientRegistry;
 
-    /**
-     * @var RouterInterface
-     */
+    /** @var RouterInterface */
     private $router;
 
-    /**
-     * @var UserManager
-     */
+    /** @var UserManager */
     private $userManager;
 
-    /**
-     * @var EventDispatcherInterface
-     */
+    /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
-    /**
-     * @var VerifyEmailHelperInterface
-     */
+    /** @var VerifyEmailHelperInterface */
     private $verifyEmailHelper;
 
-    /**
-     * @var TranslatorInterface
-     */
+    /** @var TranslatorInterface */
     private $translator;
 
     /**
@@ -106,18 +97,23 @@ class GithubRusAuthenticator extends OAuth2Authenticator
             new UserBadge($accessToken->getToken(), function () use ($request, $accessToken, $client) {
                 /** @var GithubResourceOwner $githubUser */
                 $githubUser = $client->fetchUserFromToken($accessToken);
-
-                $email = $githubUser->getEmail();
+                $githubUserEmail = $githubUser->getEmail();
 
                 // 1) have they logged in with Facebook before? Easy!
                 $existingUser = $this->userManager->getRepository()->findOneBy(['githubId' => $githubUser->getId()]);
+
+                if ($this->checkingUserSocialNetworkBeforeAuthorization($githubUserEmail)) {
+                    $request->getSession()->getFlashBag()->add('danger', $this->translator->trans('You have already logged in to the site under the username of this social network'));
+
+                    return $this->security->getUser();
+                }
 
                 if ($existingUser) {
                     return $existingUser;
                 }
 
                 // 2) do we have a matching user by email?
-                $user = $this->userManager->getRepository()->findOneBy(['email' => $email]);
+                $user = $this->userManager->getRepository()->findOneBy(['email' => $githubUserEmail]);
 
                 if (!$user) {
                     $user = UserFactory::createUserFromGithub($githubUser);

--- a/src/Security/Authenticator/Front/GoogleAuthenticator.php
+++ b/src/Security/Authenticator/Front/GoogleAuthenticator.php
@@ -6,6 +6,7 @@ namespace App\Security\Authenticator\Front;
 
 use App\Entity\User;
 use App\Event\UserLoggedInViaSocialNetworkEvent;
+use App\Utils\Authenticator\CheckingUserSocialNetworkBeforeAuthorization;
 use App\Utils\Factory\UserFactory;
 use App\Utils\Generator\PasswordGenerator;
 use App\Utils\Manager\UserManager;
@@ -27,34 +28,24 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
 class GoogleAuthenticator extends OAuth2Authenticator
 {
-    /**
-     * @var ClientRegistry
-     */
+    use CheckingUserSocialNetworkBeforeAuthorization;
+
+    /** @var ClientRegistry */
     private $clientRegistry;
 
-    /**
-     * @var RouterInterface
-     */
+    /** @var RouterInterface */
     private $router;
 
-    /**
-     * @var UserManager
-     */
+    /** @var UserManager */
     private $userManager;
 
-    /**
-     * @var EventDispatcherInterface
-     */
+    /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
-    /**
-     * @var VerifyEmailHelperInterface
-     */
+    /** @var VerifyEmailHelperInterface */
     private $verifyEmailHelper;
 
-    /**
-     * @var TranslatorInterface
-     */
+    /** @var TranslatorInterface */
     private $translator;
 
     /**
@@ -106,11 +97,16 @@ class GoogleAuthenticator extends OAuth2Authenticator
             new UserBadge($accessToken->getToken(), function () use ($request, $accessToken, $client) {
                 /** @var GoogleUser $googleUser */
                 $googleUser = $client->fetchUserFromToken($accessToken);
-
                 $email = $googleUser->getEmail();
 
                 // 1) have they logged in with Facebook before? Easy!
                 $existingUser = $this->userManager->getRepository()->findOneBy(['googleId' => $googleUser->getId()]);
+
+                if ($this->checkingUserSocialNetworkBeforeAuthorization($email)) {
+                    $request->getSession()->getFlashBag()->add('danger', $this->translator->trans('You have already logged in to the site under the username of this social network'));
+
+                    return $this->security->getUser();
+                }
 
                 if ($existingUser) {
                     return $existingUser;

--- a/src/Utils/Authenticator/CheckingUserSocialNetworkBeforeAuthorization.php
+++ b/src/Utils/Authenticator/CheckingUserSocialNetworkBeforeAuthorization.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utils\Authenticator;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Security;
+
+trait CheckingUserSocialNetworkBeforeAuthorization
+{
+    /** @var Security */
+    private $security;
+
+    /**
+     * @required
+     *
+     * @param Security $security
+     *
+     * @return self
+     */
+    public function setSecurity(Security $security): self
+    {
+        $this->security = $security;
+
+        return $this;
+    }
+
+    /**
+     * @param string $socialNetworkUserEmail
+     *
+     * @return bool
+     */
+    protected function checkingUserSocialNetworkBeforeAuthorization(string $socialNetworkUserEmail): bool
+    {
+        /** @var User $activeUser */
+        if ($activeUser = $this->security->getUser()) {
+            $activeUserEmail = $activeUser->getEmail();
+
+            if ($activeUserEmail !== $socialNetworkUserEmail) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -140,3 +140,4 @@ personal_account.social_group.link: Link
 personal_account.social_group.unlink: Unlink
 'The social network has been successfully unlinked.': 'The social network has been successfully unlinked.'
 'The social network has been successfully linked.': 'The social network has been successfully linked.'
+'You have already logged in to the site under the username of this social network': 'You have already logged in to the site under the username of this social network'

--- a/translations/messages.ru.yml
+++ b/translations/messages.ru.yml
@@ -142,3 +142,4 @@ personal_account.social_group.link: Привязать
 personal_account.social_group.unlink: Отвязать
 'The social network has been successfully unlinked.': 'Социальная сеть успешно отвязана.'
 'The social network has been successfully linked.': 'Социальная сеть успешно привязана.'
+'You have already logged in to the site under the username of this social network': 'Под логином этой социальной сети уже авторизовались на сайте'


### PR DESCRIPTION
[Pull request: hotfix/22](https://github.com/yaleksandr89/symfony-shop/pull/51)

---

Добавлена проверка на более ранюю авторизацию через выбранную социальную сеть у других пользователей. Если это было - будет выведенно сообщение об ошибке (_Под логином этой социальной сети уже авторизовались на сайте_). 

Ранее происходил редирект на учетную запись, где был записан ID пользователя социальной сети.